### PR TITLE
docs: missing import in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ It's also recommended to install [`ember-sinon-qunit`](https://github.com/elwaym
 ```js
 import Application from '../app';
 import config from '../config/environment';
+import * as QUnit from 'qunit';
 import { setApplication } from '@ember/test-helpers';
 import { start } from 'ember-qunit';
 import setupSinon from 'ember-sinon-qunit';


### PR DESCRIPTION
## Changes

Missing import from `qunit` made the code broken, because line `setupSinonAssert(QUnit.assert);` could not work.

## Ticket

N/A